### PR TITLE
release: docs quick start + live site URL

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,9 @@ name: Lint, Test & Security
 
 on:
   push:
-    branches:
-      - "**"
+    branches-ignore: 
+      - main
+      - dev
   pull_request:
     branches:
       - dev

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 **GitHub-powered Markdown content management.** Write, organize and publish your articles, posts and custom content types — **with the images they use** — versioned in your own repository.
 
-<a href="https://victor3spoir.github.io/mdvault/">Website</a> ·
-<a href="#getting-started">Getting started</a> ·
+<a href="https://mdvault-docs.vercel.app/">Website</a> ·
+<a href="#quick-start">Quick start</a> ·
 <a href="#features">Features</a>
 
 <p>
@@ -27,6 +27,49 @@ Developers keep their content in Git — but editing raw Markdown files, uploadi
 - **No database.** The repository *is* the database.
 - **No lock-in.** Plain Markdown with YAML frontmatter, readable by any static site generator.
 - **Full history.** Every create, update, publish or delete is a commit.
+
+## Quick start
+
+You need a GitHub repository for your content and a personal access token that can write to it ([permissions below](#github-token-permissions)).
+
+MDVault is published to GitHub Container Registry. Bind it to loopback so it is only reachable from your machine:
+
+```bash
+docker run -d \
+  --name mdvault \
+  -p 127.0.0.1:3000:3000 \
+  -e GITHUB_TOKEN=your_token \
+  -e GITHUB_OWNER=your_username \
+  -e GITHUB_REPO=your_repo \
+  --restart unless-stopped \
+  ghcr.io/victor3spoir/mdvault:latest
+```
+
+<details>
+<summary>Or with Docker Compose</summary>
+
+```yaml
+services:
+  mdvault:
+    image: ghcr.io/victor3spoir/mdvault:latest
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      GITHUB_TOKEN: "your_personal_access_token"
+      GITHUB_OWNER: "your_github_username"
+      GITHUB_REPO: "your_content_repository"
+    restart: unless-stopped
+```
+
+```bash
+docker compose up -d
+```
+
+</details>
+
+Open **http://127.0.0.1:3000** and start writing — or go to **Settings → Dynamic Content** to define your own content types.
+
+> Prefer to run it from source? See [Development](#development). Full configuration is in [Configuration](#configuration).
 
 ## Features
 
@@ -98,49 +141,7 @@ your-content-repo/
     └── docs/               # custom type
 ```
 
-## Getting Started
-
-### Prerequisites
-
-- A GitHub repository for storing content
-- A GitHub personal access token with read/write access to that repository
-- Docker and Docker Compose, or Bun for local development
-
-### Quick start with Docker
-
-MDVault is published to GitHub Container Registry. Bind the container to loopback so it is reachable only from the host:
-
-```yaml
-services:
-  mdvault:
-    image: ghcr.io/victor3spoir/mdvault:latest
-    ports:
-      - "127.0.0.1:3000:3000"
-    environment:
-      GITHUB_TOKEN: "your_personal_access_token"
-      GITHUB_OWNER: "your_github_username"
-      GITHUB_REPO: "your_content_repository"
-    restart: unless-stopped
-```
-
-```bash
-docker compose up -d
-```
-
-Or with Docker directly:
-
-```bash
-docker run -d \
-  --name mdvault \
-  -p 127.0.0.1:3000:3000 \
-  -e GITHUB_TOKEN=your_token \
-  -e GITHUB_OWNER=your_username \
-  -e GITHUB_REPO=your_repo \
-  --restart unless-stopped \
-  ghcr.io/victor3spoir/mdvault:latest
-```
-
-Open [http://127.0.0.1:3000](http://127.0.0.1:3000), then head to **Settings → Dynamic Content** to define your own asset types, or start writing straight away.
+## Configuration
 
 ### Environment variables
 
@@ -222,7 +223,7 @@ HOST=127.0.0.1 PORT=3000 bun .output/server/index.mjs
 
 ## Documentation site
 
-The presentation site lives in [`docs/`](./docs) and deploys to Vercel: set the project's **Root Directory** to `docs` and the rest is read from `docs/vercel.json`. See [`docs/README.md`](./docs/README.md) for details.
+The presentation site is live at **[mdvault-docs.vercel.app](https://mdvault-docs.vercel.app/)** and lives in [`docs/`](./docs). It deploys to Vercel with the project's **Root Directory** set to `docs`; everything else is read from `docs/vercel.json`. See [`docs/README.md`](./docs/README.md) for details.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ Canonical, OpenGraph, `robots.txt` and `sitemap.xml` need an absolute URL.
 1. `SITE_URL` — set this once you have a custom domain
 2. `VERCEL_PROJECT_PRODUCTION_URL` — set automatically by Vercel
 3. `VERCEL_URL` — preview deployments
-4. `https://mdvault.vercel.app` — local fallback
+4. `https://mdvault-docs.vercel.app` — local fallback
 
 Production and preview deployments are therefore correct out of the box. After
 attaching a custom domain, add `SITE_URL=https://your-domain.com` to the

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,10 +55,10 @@
 				<span>mdvault</span>
 			</a>
 			<nav class="nav__links">
+				<a href="#start">Get started</a>
 				<a href="#features">Features</a>
 				<a href="#screens">Screens</a>
 				<a href="#how">How it works</a>
-				<a href="#start">Get started</a>
 			</nav>
 			<div class="nav__actions">
 				<button
@@ -173,7 +173,41 @@
 				</div>
 			</section>
 
-			<section class="section section--alt" id="features">
+			<section class="section section--alt" id="start">
+				<div class="container narrow">
+					<h2>Getting started</h2>
+
+					<h3 class="step-title"><i data-icon="key"></i> 1. Prepare a repository &amp; token</h3>
+					<p>
+						Create (or pick) a GitHub repository for your content, then generate
+						a fine-grained personal access token limited to it with
+						<strong>Contents: read and write</strong> and
+						<strong>Metadata: read-only</strong>.
+					</p>
+
+					<h3 class="step-title"><i data-icon="brand-docker"></i> 2. Run with Docker</h3>
+					<pre><code>services:
+  mdvault:
+    image: ghcr.io/victor3spoir/mdvault:latest
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      GITHUB_TOKEN: "your_personal_access_token"
+      GITHUB_OWNER: "your_github_username"
+      GITHUB_REPO: "your_content_repository"
+    restart: unless-stopped</code></pre>
+					<pre><code>docker compose up -d</code></pre>
+
+					<h3 class="step-title"><i data-icon="browser"></i> 3. Open the app</h3>
+					<p>
+						Visit <code>http://127.0.0.1:3000</code>, then head to
+						<strong>Settings → Dynamic Content</strong> to define your own asset
+						types, or start writing straight away.
+					</p>
+				</div>
+			</section>
+
+			<section class="section" id="features">
 				<div class="container">
 					<h2>Features</h2>
 					<p class="section__lead">
@@ -218,7 +252,7 @@
 				</div>
 			</section>
 
-			<section class="section" id="screens">
+			<section class="section section--alt" id="screens">
 				<div class="container">
 					<h2>Inside the app</h2>
 					<p class="section__lead">
@@ -297,7 +331,7 @@
 				</div>
 			</section>
 
-			<section class="section section--alt" id="how">
+			<section class="section" id="how">
 				<div class="container wide">
 					<h2>How it works</h2>
 					<p class="section__lead">
@@ -379,39 +413,10 @@
 				</div>
 			</section>
 
-			<section class="section" id="start">
+			<section class="section section--alt" id="config">
 				<div class="container narrow">
-					<h2>Getting started</h2>
+					<h2>Configuration</h2>
 
-					<h3 class="step-title"><i data-icon="key"></i> 1. Prepare a repository &amp; token</h3>
-					<p>
-						Create (or pick) a GitHub repository for your content, then generate
-						a fine-grained personal access token limited to it with
-						<strong>Contents: read and write</strong> and
-						<strong>Metadata: read-only</strong>.
-					</p>
-
-					<h3 class="step-title"><i data-icon="brand-docker"></i> 2. Run with Docker</h3>
-					<pre><code>services:
-  mdvault:
-    image: ghcr.io/victor3spoir/mdvault:latest
-    ports:
-      - "127.0.0.1:3000:3000"
-    environment:
-      GITHUB_TOKEN: "your_personal_access_token"
-      GITHUB_OWNER: "your_github_username"
-      GITHUB_REPO: "your_content_repository"
-    restart: unless-stopped</code></pre>
-					<pre><code>docker compose up -d</code></pre>
-
-					<h3 class="step-title"><i data-icon="browser"></i> 3. Open the app</h3>
-					<p>
-						Visit <code>http://127.0.0.1:3000</code>, then head to
-						<strong>Settings → Dynamic Content</strong> to define your own asset
-						types, or start writing straight away.
-					</p>
-
-					<h3 class="step-title"><i data-icon="settings"></i> Configuration</h3>
 					<div class="table-wrap">
 						<table>
 							<thead>

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -20,7 +20,7 @@ function resolveSiteUrl() {
 		process.env.VERCEL_URL;
 
 	if (!host) {
-		return "https://mdvault.vercel.app";
+		return "https://mdvault-docs.vercel.app";
 	}
 
 	return (host.startsWith("http") ? host : `https://${host}`).replace(


### PR DESCRIPTION
Promotes `dev` to `main`. Contains #23.

- **Quick start** moved to just after the description in both the README and the documentation site; the environment table, token permissions and security model stay lower as **Configuration**.
- Website link and site-URL fallback now point at **https://mdvault-docs.vercel.app/**, so canonical, OpenGraph, `robots.txt` and `sitemap.xml` resolve to the live deployment.
- Docs nav order mirrors the page; section striping corrected.
- Includes the `lint.yml` trigger change.

Docs build clean, README anchors and image paths verified.

> ⚠️ CI still cannot run — the account remains locked for billing.